### PR TITLE
Added features: List of allowed openid_providers; Group assignment based on OpenId Provider

### DIFF
--- a/action.php
+++ b/action.php
@@ -78,10 +78,10 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 			$this,
 			'handle_act_unknown',
 			array());
-    $controller->register_hook('ACTION_ACT_PREPROCESS',
-      'AFTER',
-      $this,
-      'assigngroup');
+		$controller->register_hook('ACTION_ACT_PREPROCESS',
+			'AFTER',
+			$this,
+			'assigngroup');
 	}
 
 	/**
@@ -104,7 +104,7 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 
 	/**
 	 * Return an OpenID Consumer
-	 */    
+	 */
 	function getConsumer()
 	{
 		global $conf;
@@ -132,7 +132,7 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 		global $ID, $conf, $auth;
 
 		$user = $_SERVER['REMOTE_USER'];
-        
+		
 		// Do not ask the user a password he didn't set
 		if ($event->data == 'profile') {
 			$conf['profileconfirm'] = 0;
@@ -157,31 +157,31 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 			// not sure this if it's useful there
 			$event->stopPropagation();
 			$event->preventDefault();
-      $conf_allowedproviders = $this->getConf('allowedproviders');
+			$conf_allowedproviders = $this->getConf('allowedproviders');
 
 			if (isset($_POST['mode']) && ($_POST['mode'] == 'login' || $_POST['mode'] == 'add')) {
 
-        // See if submitted provider is allowed or not
-        if (empty($conf_allowedproviders)) {
-          // Allow any provider
-          // User needs to fill in full identifier URL.
-          $openid_identifier = $_POST['openid_identifier'];
-        } else {
-          // Get it from the selected option
-          $openid_provider = $_POST['openid_provider'];
+				// See if submitted provider is allowed or not
+				if (empty($conf_allowedproviders)) {
+					// Allow any provider
+					// User needs to fill in full identifier URL.
+					$openid_identifier = $_POST['openid_identifier'];
+				} else {
+					// Get it from the selected option
+					$openid_provider = $_POST['openid_provider'];
 
-          // Create identifier for user. Replace '*' by username.
-          $openid_identifier = $openid_provider;
-          $openid_identifier = str_replace('*', $_POST['nickname'], $openid_identifier);
-          
-          $validprovider   = $this->check_provider($openid_provider);
-          $valididentifier = $this->check_identifier($openid_identifier);
+					// Create identifier for user. Replace '*' by username.
+					$openid_identifier = $openid_provider;
+					$openid_identifier = str_replace('*', $_POST['nickname'], $openid_identifier);
+					
+					$validprovider   = $this->check_provider($openid_provider);
+					$valididentifier = $this->check_identifier($openid_identifier);
 
-          if( !$validprovider or !$valididentifier ) {
-            msg($this->getLang('enter_valid_openid_error'), -1);
-					  return;
-          }
-        }
+					if( !$validprovider or !$valididentifier ) {
+						msg($this->getLang('enter_valid_openid_error'), -1);
+						return;
+					}
+				}
 
 				// we try to login with the OpenID submited
 				$consumer = $this->getConsumer();
@@ -222,14 +222,14 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 				$response = $consumer->complete($this->_self('openid'));
 				// set session variable depending on authentication result
 				if ($response->status == Auth_OpenID_SUCCESS) {
-          $openid_identifier = $_GET['openid_identity'];
-          
-          $isallowed = $this->check_identifier($openid_identifier);
+					$openid_identifier = $_GET['openid_identity'];
+					
+					$isallowed = $this->check_identifier($openid_identifier);
 
-          if (!$isallowed) {
-            msg($this->getlang('enter_valid_openid_error'), -1);
-            return;
-          }
+					if (!$isallowed) {
+						msg($this->getlang('enter_valid_openid_error'), -1);
+						return;
+					}
 
 					$openid = isset($_GET['openid1_claimed_id']) ? $_GET['openid1_claimed_id'] : $_GET['openid_claimed_id'];
 					if (empty($openid)) {
@@ -262,7 +262,7 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 			}
 
 		}
-        
+		
 		return; // fall through to what ever action was called
 	}
 
@@ -337,25 +337,25 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 
 	/**
 	 * Generate the OpenID login/complete forms
-	 */    
+	 */
 	function get_openid_form($mode)
 	{
 		global $USERINFO, $lang, $conf;
-    
+		
 		$c = 'block';
 		$p = array('size'=>'50');
 
 
-    $conf_allowedproviders = $this->getConf('allowedproviders');
-    if( empty($conf_allowedproviders) ) {
-      $providers = null;
-    } else {
-      $providers = array();
-      foreach( explode(' ', $conf_allowedproviders) as $provider) {
-        $provider_label = parse_url($provider, PHP_URL_HOST);
-        $providers[$provider] = $provider_label;
-      }
-    }
+		$conf_allowedproviders = $this->getConf('allowedproviders');
+		if( empty($conf_allowedproviders) ) {
+			$providers = null;
+		} else {
+			$providers = array();
+			foreach( explode(' ', $conf_allowedproviders) as $provider) {
+				$provider_label = parse_url($provider, PHP_URL_HOST);
+				$providers[$provider] = $provider_label;
+			}
+		}
 
 		$form = new Doku_Form('openid__login', script());
 		$form->addHidden('id', $_GET['id']);
@@ -371,29 +371,29 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 			$form->startFieldset($this->getLang('openid_login_fieldset'));
 			$form->addHidden('mode', 'login');
 
-      if ( !is_array($providers) ) {
-			  $form->addElement(form_makeTextField('openid_identifier', $_REQUEST['openid_identifier'], $this->getLang('openid_url_label'), 'openid__url', $c, $p));
-      } else {
-        $params = array();
-        $form->addElement(
-          form_makeListboxField(
-            'openid_provider',
-            $providers,
-            $_REQUEST['openid_provider'], #default
-            $this->getLang('openid_provider_label'),
-            '',
-            'block',
-            $params
-          )
-        );
-        $form->addElement(form_makeTextField('nickname', $_REQUEST['nickname'], $lang['user'], null, $c, $p));
-      }
+			if ( !is_array($providers) ) {
+				$form->addElement(form_makeTextField('openid_identifier', $_REQUEST['openid_identifier'], $this->getLang('openid_url_label'), 'openid__url', $c, $p));
+			} else {
+				$params = array();
+				$form->addElement(
+					form_makeListboxField(
+						'openid_provider',
+						$providers,
+						$_REQUEST['openid_provider'], #default
+						$this->getLang('openid_provider_label'),
+						'',
+						'block',
+						$params
+					)
+				);
+				$form->addElement(form_makeTextField('nickname', $_REQUEST['nickname'], $lang['user'], null, $c, $p));
+			}
 			$form->addElement(form_makeButton('submit', '', $lang['btn_login']));
 		}
 		$form->endFieldset();
 		return $form;
 	}
-    
+	
 	/**
 	 * Insert link to OpenID into usual login form
 	 */
@@ -593,92 +593,92 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 		return $openid_associations;
 	}
 	
-  function allowedproviders() {
-    $conf_allowedproviders = $this->getConf('allowedproviders');
-    if (empty($conf_allowedproviders) ) {
-      return array();
-    } else {
-      return explode(' ', $conf_allowedproviders);
-    }
-  }
+	function allowedproviders() {
+		$conf_allowedproviders = $this->getConf('allowedproviders');
+		if (empty($conf_allowedproviders) ) {
+			return array();
+		} else {
+			return explode(' ', $conf_allowedproviders);
+		}
+	}
 
-  function user_getproviders($user) {
-    if (empty($user)) {
-      return array();
-    }
-    // See if logged in through openid
-    if (preg_match('|^https?://|', $user)) {
-      if( $this->check_identifier($user) ) {
-        return array(parse_url($user, PHP_URL_HOST));
-      }
-      
-    }
-    $associations = $this->get_associations($user);
-    $providers=array();
-    foreach ($associations as $openid_identifier => $username) {
-      $providers[] = $this->check_identifier($openid_identifier);
-    }
-    return $providers;
-  }
+	function user_getproviders($user) {
+		if (empty($user)) {
+			return array();
+		}
+		// See if logged in through openid
+		if (preg_match('|^https?://|', $user)) {
+			if( $this->check_identifier($user) ) {
+				return array(parse_url($user, PHP_URL_HOST));
+			}
+			
+		}
+		$associations = $this->get_associations($user);
+		$providers=array();
+		foreach ($associations as $openid_identifier => $username) {
+			$providers[] = $this->check_identifier($openid_identifier);
+		}
+		return $providers;
+	}
 
-  /**
-   * Inspired by: http://subversion.fem.tu-ilmenau.de/websvn/wsvn/dokuwiki/ipgroup/action.php
-   */ 
-  function assigngroup(&$event, $param) {
-    global $USERINFO, $INFO, $ID;
-    $user = $_SERVER['REMOTE_USER'];
-    $providers = $this->user_getproviders($user);
-    
-    foreach ($providers as $provider) {
-      if (!empty($USERINFO)) {
-        $USERINFO['grps'][] = $provider;
-      }
-      $INFO['userinfo']['grps'][] = $provider;
-      $INFO['perm']     = auth_aclcheck($ID, '', $INFO['userinfo']['grps']);
-      $INFO['writable'] = (is_writable($INFO['filepath']) && $INFO['perm'] >= AUTH_EDIT);
-    }
-    #$INFO['userinfo']['name'] = str_replace(array('https://','http://', $providers[0]),'', $INFO['userinfo']['name']);
-    
-    $INFO['client'] = $_SESSION[DOKU_COOKIE]['openid_fullname'];
-    print '<pre>';
-    print_r($INFO['userinfo']);
-    print '</pre>';
-  }
+	/**
+	 * Inspired by: http://subversion.fem.tu-ilmenau.de/websvn/wsvn/dokuwiki/ipgroup/action.php
+	 */ 
+	function assigngroup(&$event, $param) {
+		global $USERINFO, $INFO, $ID;
+		$user = $_SERVER['REMOTE_USER'];
+		$providers = $this->user_getproviders($user);
+		
+		foreach ($providers as $provider) {
+			if (!empty($USERINFO)) {
+				$USERINFO['grps'][] = $provider;
+			}
+			$INFO['userinfo']['grps'][] = $provider;
+			$INFO['perm']     = auth_aclcheck($ID, '', $INFO['userinfo']['grps']);
+			$INFO['writable'] = (is_writable($INFO['filepath']) && $INFO['perm'] >= AUTH_EDIT);
+		}
+		#$INFO['userinfo']['name'] = str_replace(array('https://','http://', $providers[0]),'', $INFO['userinfo']['name']);
+		
+		$INFO['client'] = $_SESSION[DOKU_COOKIE]['openid_fullname'];
+		print '<pre>';
+		print_r($INFO['userinfo']);
+		print '</pre>';
+	}
 
-  function provider_group($openid_provider) {
-    $group = $openid_provider;
-    $group = str_replace("*", $group);
-    $group = str_replace(array('https://', 'http://'), '', $group);
-    $group = trimr($group, '/');
-    return $group;
-  }
+	function provider_group($openid_provider) {
+		$group = $openid_provider;
+		$group = str_replace("*", $group);
+		$group = str_replace(array('https://', 'http://'), '', $group);
+		$group = trimr($group, '/');
+		return $group;
+	}
 
-  function check_provider($openid_provider) {
-      $conf_allowedproviders = $this->getConf('allowedproviders');
-      if (empty($conf_allowedproviders) ) {
-        return true;
-      }
-      $allowedproviders = explode(' ', $conf_allowedproviders);
-      $valid = in_array($openid_provider, $allowedproviders);
-      return $valid;
-  }
-  
-  function check_identifier($openid_identifier) {
-      // Check if identity matches allowed provider.
-      // Identity: http://openid.example.com/johndoe/
-      // Provider: http://openid.example.com/*/
-      $conf_allowedproviders = $this->getConf('allowedproviders');
-      if (empty($conf_allowedproviders) ) {
-        return parse_urL($openid_identifier, PHP_URL_HOST);
-      }
+	function check_provider($openid_provider) {
+			$conf_allowedproviders = $this->getConf('allowedproviders');
+			if (empty($conf_allowedproviders) ) {
+				return true;
+			}
+			$allowedproviders = explode(' ', $conf_allowedproviders);
+			$valid = in_array($openid_provider, $allowedproviders);
+			return $valid;
+	}
+	
+	function check_identifier($openid_identifier) {
+			// Check if identity matches allowed provider.
+			// Identity: http://openid.example.com/johndoe/
+			// Provider: http://openid.example.com/*/
+			$conf_allowedproviders = $this->getConf('allowedproviders');
+			if (empty($conf_allowedproviders) ) {
+				return parse_urL($openid_identifier, PHP_URL_HOST);
+			}
 
-      $allowedproviders = explode(' ', $conf_allowedproviders);
-      $isallowed = false;
-      foreach ($allowedproviders as $allowedprovider) {
-        if( fnmatch( $allowedprovider, $openid_identifier ) ) {
-          return parse_url($allowedprovider, PHP_URL_HOST);
-        }
-      }
-      return false;
-  }
+			$allowedproviders = explode(' ', $conf_allowedproviders);
+			$isallowed = false;
+			foreach ($allowedproviders as $allowedprovider) {
+				if( fnmatch( $allowedprovider, $openid_identifier ) ) {
+					return parse_url($allowedprovider, PHP_URL_HOST);
+				}
+			}
+			return false;
+	}
 }

--- a/action.php
+++ b/action.php
@@ -654,8 +654,13 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 				return true;
 			}
 			$allowedproviders = explode(' ', $conf_allowedproviders);
-			$valid = in_array($openid_provider, $allowedproviders);
-			return $valid;
+			$host = parse_url($openid_provider, PHP_URL_HOST);
+			foreach ($allowedproviders as $provider) {
+				if (parse_url($provider, PHP_URL_HOST) == $host) {
+					return true;
+				}
+			}
+			return false;
 	}
 	
 	function check_identifier($openid_identifier)
@@ -667,11 +672,11 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 			if (empty($conf_allowedproviders) ) {
 				return true;
 			}
-
 			$allowedproviders = explode(' ', $conf_allowedproviders);
 			$isallowed = false;
+			$host = parse_url($openid_identifier, PHP_URL_HOST);
 			foreach ($allowedproviders as $allowedprovider) {
-				if( fnmatch( $allowedprovider, $openid_identifier ) ) {
+				if (parse_url($allowedprovider, PHP_URL_HOST) == $host) {
 					return true;
 				}
 			}

--- a/action.php
+++ b/action.php
@@ -640,8 +640,6 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 			$INFO['perm']     = auth_aclcheck($ID, '', $INFO['userinfo']['grps']);
 			$INFO['writable'] = (is_writable($INFO['filepath']) && $INFO['perm'] >= AUTH_EDIT);
 		}
-		
-		$INFO['client'] = $_SESSION[DOKU_COOKIE]['openid_fullname'];
 	}
 
 	function check_provider($openid_provider)

--- a/action.php
+++ b/action.php
@@ -640,21 +640,8 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 			$INFO['perm']     = auth_aclcheck($ID, '', $INFO['userinfo']['grps']);
 			$INFO['writable'] = (is_writable($INFO['filepath']) && $INFO['perm'] >= AUTH_EDIT);
 		}
-		#$INFO['userinfo']['name'] = str_replace(array('https://','http://', $providers[0]),'', $INFO['userinfo']['name']);
 		
 		$INFO['client'] = $_SESSION[DOKU_COOKIE]['openid_fullname'];
-		print '<pre>';
-		print_r($INFO['userinfo']);
-		print '</pre>';
-	}
-
-	function provider_group($openid_provider)
-	{
-		$group = $openid_provider;
-		$group = str_replace("*", $group);
-		$group = str_replace(array('https://', 'http://'), '', $group);
-		$group = trimr($group, '/');
-		return $group;
 	}
 
 	function check_provider($openid_provider)

--- a/action.php
+++ b/action.php
@@ -636,10 +636,11 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 		global $USERINFO, $INFO, $ID;
 		$user = $_SERVER['REMOTE_USER'];
 		$providers = $this->user_getproviders($user);
-		
 		foreach ($providers as $provider) {
 			if (!empty($USERINFO)) {
 				$USERINFO['grps'][] = $provider;
+			} else {
+				$INFO['userinfo']['name'] = parse_url($INFO['userinfo']['name'], PHP_URL_HOST);
 			}
 			$INFO['userinfo']['grps'][] = $provider;
 			$INFO['perm']     = auth_aclcheck($ID, '', $INFO['userinfo']['grps']);
@@ -665,6 +666,6 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 	
 	function check_identifier($openid_identifier)
 	{
-			return $this->check_provider($openid_provider);
+			return $this->check_provider($openid_identifier);
 	}
 }

--- a/action.php
+++ b/action.php
@@ -653,13 +653,11 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 		$providers = $this->user_getproviders($user);
 		
 		foreach ($providers as $provider) {
-			#die(json_encode($USERINFO));
 			if (!empty($USERINFO)) {
 				$USERINFO['grps'][] = $provider;
 			}
 			$INFO['userinfo']['grps'][] = $provider;
 			$INFO['perm']     = auth_aclcheck($ID, '', $INFO['userinfo']['grps']);
-		#	die(json_encode($INFO['perm']));	
 			# Copied from inc/common.php:153-159
 			# Even though act_permcheck can properly check permissions
 			#  after $INFO['perm'] is set, the writable and editable variables

--- a/action.php
+++ b/action.php
@@ -593,7 +593,8 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 		return $openid_associations;
 	}
 	
-	function allowedproviders() {
+	function allowedproviders()
+	{
 		$conf_allowedproviders = $this->getConf('allowedproviders');
 		if (empty($conf_allowedproviders) ) {
 			return array();
@@ -602,7 +603,8 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 		}
 	}
 
-	function user_getproviders($user) {
+	function user_getproviders($user)
+	{
 		if (empty($user)) {
 			return array();
 		}
@@ -624,7 +626,8 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 	/**
 	 * Inspired by: http://subversion.fem.tu-ilmenau.de/websvn/wsvn/dokuwiki/ipgroup/action.php
 	 */ 
-	function assigngroup(&$event, $param) {
+	function assigngroup(&$event, $param)
+	{
 		global $USERINFO, $INFO, $ID;
 		$user = $_SERVER['REMOTE_USER'];
 		$providers = $this->user_getproviders($user);
@@ -645,7 +648,8 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 		print '</pre>';
 	}
 
-	function provider_group($openid_provider) {
+	function provider_group($openid_provider)
+	{
 		$group = $openid_provider;
 		$group = str_replace("*", $group);
 		$group = str_replace(array('https://', 'http://'), '', $group);
@@ -653,7 +657,8 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 		return $group;
 	}
 
-	function check_provider($openid_provider) {
+	function check_provider($openid_provider)
+	{
 			$conf_allowedproviders = $this->getConf('allowedproviders');
 			if (empty($conf_allowedproviders) ) {
 				return true;
@@ -663,7 +668,8 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 			return $valid;
 	}
 	
-	function check_identifier($openid_identifier) {
+	function check_identifier($openid_identifier)
+	{
 			// Check if identity matches allowed provider.
 			// Identity: http://openid.example.com/johndoe/
 			// Provider: http://openid.example.com/*/

--- a/action.php
+++ b/action.php
@@ -171,11 +171,6 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
             msg($this->getLang('enter_valid_openid_error'), -1);
 					  return;
           }
-
-          // Prepend http://
-          if( substr($openid_provider, 0, strlen('http://')) !== 'http://' ) {
-            $openid_provider = "http://{$openid_provider}";
-          }
           
           // Create identifier for user. Replace '*' by username.
           $openid_identifier = $openid_provider;

--- a/action.php
+++ b/action.php
@@ -583,7 +583,7 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 			include(DOKU_CONF.'openid.php');
 			$this->openid_associations = $openid_associations;
 		} else {
-			$this->openid_associations = $openid_associations = $openid_associations = array();
+			$this->openid_associations = $openid_associations = array();
 		}
 		// Maybe is there a better way to filter the array
 		if (!empty($username)) {

--- a/action.php
+++ b/action.php
@@ -665,21 +665,6 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 	
 	function check_identifier($openid_identifier)
 	{
-			// Check if identity matches allowed provider.
-			// Identifier: http://openid.example.com/johndoe/
-			// Provider: http://openid.example.com/*/
-			$conf_allowedproviders = $this->getConf('allowedproviders');
-			if (empty($conf_allowedproviders) ) {
-				return true;
-			}
-			$allowedproviders = explode(' ', $conf_allowedproviders);
-			$isallowed = false;
-			$host = parse_url($openid_identifier, PHP_URL_HOST);
-			foreach ($allowedproviders as $allowedprovider) {
-				if (parse_url($allowedprovider, PHP_URL_HOST) == $host) {
-					return true;
-				}
-			}
-			return false;
+			return check_provider($openid_provider);
 	}
 }

--- a/action.php
+++ b/action.php
@@ -665,6 +665,6 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 	
 	function check_identifier($openid_identifier)
 	{
-			return check_provider($openid_provider);
+			return $this->check_provider($openid_provider);
 	}
 }

--- a/action.php
+++ b/action.php
@@ -639,12 +639,17 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 		foreach ($providers as $provider) {
 			if (!empty($USERINFO)) {
 				$USERINFO['grps'][] = $provider;
-			} else {
-				$INFO['userinfo']['name'] = parse_url($INFO['userinfo']['name'], PHP_URL_HOST);
 			}
 			$INFO['userinfo']['grps'][] = $provider;
 			$INFO['perm']     = auth_aclcheck($ID, '', $INFO['userinfo']['grps']);
-			$INFO['writable'] = (is_writable($INFO['filepath']) && $INFO['perm'] >= AUTH_EDIT);
+			$INFO['writable'] = false;
+			if ($INFO['perm'] >= AUTH_EDIT) {
+				if (file_exists($INFO['filepath'])) {
+					$INFO['writable'] = is_writable($INFO['filepath']);
+				} else {
+					$INFO['writable'] = is_writable(dirname($INFO['filepath']));
+				}
+			}
 		}
 	}
 

--- a/conf/default.php
+++ b/conf/default.php
@@ -4,4 +4,6 @@
  */
 $conf['allowedproviders']  = '';      // list of allowed OpenID servers
 $conf['loginopenid']  = true;      // list of allowed OpenID servers
+$conf['register_allow'] = false;	// allow registration through openid
+$conf['register_lock_username'] = false; // lock username on registration (users can't choose their name)
 

--- a/conf/default.php
+++ b/conf/default.php
@@ -3,3 +3,5 @@
  * Options for the OpenID Plugin
  */
 $conf['allowedproviders']  = '';      // list of allowed OpenID servers
+$conf['loginopenid']  = true;      // list of allowed OpenID servers
+

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Options for the OpenID Plugin
+ */
+$conf['allowedproviders']  = '';      // list of allowed OpenID servers

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Metadata for configuration manager plugin
+ */
+$meta['allowedproviders'] = array('string');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -3,3 +3,4 @@
  * Metadata for configuration manager plugin
  */
 $meta['allowedproviders'] = array('string');
+$meta['loginopenid'] = array('onoff');;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -3,4 +3,7 @@
  * Metadata for configuration manager plugin
  */
 $meta['allowedproviders'] = array('string');
-$meta['loginopenid'] = array('onoff');;
+$meta['loginopenid'] = array('onoff');
+$meta['register_allow'] = array('onoff');
+$meta['register_lock_username'] = array('onoff');
+

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -10,8 +10,9 @@ $lang['add_button']             = 'Add';
 $lang['complete_button']        = 'Complete';
 $lang['delete_selected_button'] = 'Delete selected';
 
-$lang['login_link']   = 'You may <a href="%s" class="openid">login with OpenID</a>, too.';
-$lang['manage_link']  = 'You can also <a href="%s">manage your OpenID identities</a>';
+$lang['login_link']         = 'You may <a href="%s" class="openid">login with OpenID</a>, too.';
+$lang['login_link_normal']  = 'Login <a href="%s">without OpenID</a>.';
+$lang['manage_link']        = 'You can also <a href="%s">manage your OpenID identities</a>';
 
 $lang['add_openid_title']         = 'Add an OpenID';
 $lang['openid_identities_title']  = 'Your OpenID identities';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -4,6 +4,7 @@ $lang['openid_login_fieldset']    = 'OpenID Login';
 $lang['openid_account_fieldset']  = 'OpenID Account';
 
 $lang['openid_url_label'] = 'OpenID URL';
+$lang['openid_provider_label'] = 'OpenID Provider';
 
 $lang['add_button']             = 'Add';
 $lang['complete_button']        = 'Complete';
@@ -26,5 +27,4 @@ $lang['openid_authentication_canceled'] = 'OpenID authentication canceled.';
 
 $lang['openid_complete_text'] = 'Please now verify or complete your account informations to finish registration.';
 $lang['openid_complete_disabled_text'] = 'You\'re correctly authenticated but registration is not possible on this wiki. <a href="%s">Continue there.</a>';
-
 $lang['none'] = 'None.';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -27,5 +27,5 @@ $lang['openid_authentication_failed']   = 'OpenID authentication failed';
 $lang['openid_authentication_canceled'] = 'OpenID authentication canceled.';
 
 $lang['openid_complete_text'] = 'Please now verify or complete your account informations to finish registration.';
-$lang['openid_complete_disabled_text'] = 'You\'re correctly authenticated but registration is not possible on this wiki. <a href="%s">Continue there.</a>';
+$lang['openid_complete_disabled_text'] = 'You\'re now logged in. You will be redirected to <a href="%s">this page.</a>';
 $lang['none'] = 'None.';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2,3 +2,6 @@
 
 $lang['allowedproviders'] = 'Allowed OpenID providers (space delimited).<br/><code>*</code> will be replaced by the username.<br/>E.g. <code>http://openid.example.com/*/</code>';
 $lang['loginopenid'] = 'Default to OpenID login form.';
+$lang['register_allow'] = 'Allow registration after logging in with OpenID';
+$lang['register_lock_username'] = 'Lock username on Registration';
+

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,4 +1,4 @@
 <?php
 
-$lang['allowedproviders'] = 'List of allowed OpenID providers. Empty to allow all.';
+$lang['allowedproviders'] = 'Allowed OpenID providers (space delimited).<br/><code>*</code> will be replaced by the username.<br/>E.g. <code>http://openid.example.com/*/</code>';
 $lang['loginopenid'] = 'Default to OpenID login form.';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,3 +1,4 @@
 <?php
 
 $lang['allowedproviders'] = 'List of allowed OpenID providers. Empty to allow all.';
+$lang['loginopenid'] = 'Default to OpenID login form.';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,3 @@
+<?php
+
+$lang['allowedproviders'] = 'List of allowed OpenID providers. Empty to allow all.';


### PR DESCRIPTION
In configuration panel, the admin can specify a list of allowed openid_providers.

For example:

http://openid.example.com/*

Will be used to match openid identities such as:
http://openid.example.com/john123

After logging in, the user will be assigned to the group @openid.example.com and can be given special permissions.
