### PR TITLE
Replaced deprecated plugin_locale_xhtml call with locale_xhtml. 

### DIFF
--- a/action.php
+++ b/action.php
@@ -248,7 +248,7 @@ class action_plugin_openid extends DokuWiki_Action_Plugin {
 		$user = $_SERVER['REMOTE_USER'];
 
 		if (empty($user)) {
-			print $this->plugin_locale_xhtml('intro');
+			print $this->locale_xhtml('intro');
 			print '<div class="centeralign">'.NL;
 			$form = $this->get_openid_form('login');
 			html_form('register', $form);


### PR DESCRIPTION
Deprecated function was removed from DokuWiki as of 2013/02/17 ( https://github.com/splitbrain/dokuwiki/commit/c33b315b ). This change is required to make the plugin compatible with Weatherwax. 
